### PR TITLE
Remove unirest; Add in faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'puma', '~> 3.11'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'rack-cors'
 gem 'active_model_serializers'
-gem 'unirest'
+gem 'faraday', '~> 0.9.2'
 gem 'dotenv-rails', groups: [:development, :test]
 gem "bcrypt", "~> 3.1"
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
     arel (9.0.0)
     ast (2.4.0)
     bcrypt (3.1.12)
@@ -69,6 +68,8 @@ GEM
     erubi (1.8.0)
     faker (1.9.3)
       i18n (>= 0.7)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -90,12 +91,12 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mime-types (1.25.1)
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.6)
+    multipart-post (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -146,8 +147,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rest-client (1.6.9)
-      mime-types (~> 1.16)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -198,10 +197,6 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
-    unirest (1.1.2)
-      addressable (~> 2.3.5)
-      json (~> 1.8.1)
-      rest-client (~> 1.6.7)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -216,6 +211,7 @@ DEPENDENCIES
   byebug
   dotenv-rails
   faker
+  faraday (~> 0.9.2)
   jwt
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
@@ -230,7 +226,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
-  unirest
 
 RUBY VERSION
    ruby 2.5.1p57


### PR DESCRIPTION
Unirest was unmaintained and had a dependency on an earlier version of rest-client that resulted in a security vulnerability. Opting to use a better maintained gem here with Faraday